### PR TITLE
api: Remove ModelSlug enum.

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covid-modeling/api",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "main": "dist/src/index",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/api/schema/runner.json
+++ b/packages/api/schema/runner.json
@@ -54,7 +54,7 @@
           "type": "string"
         },
         "slug": {
-          "$ref": "#/definitions/ModelSlug"
+          "type": "string"
         }
       },
       "required": [
@@ -121,15 +121,6 @@
         "interventionPeriods"
       ],
       "type": "object"
-    },
-    "ModelSlug": {
-      "enum": [
-        "mrc-ide-covid-sim",
-        "basel",
-        "mc19",
-        "idm-covasim"
-      ],
-      "type": "string"
     },
     "RequestInput": {
       "additionalProperties": false,

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -18,21 +18,14 @@ export enum RunStatus {
 }
 
 export interface RunOutput {
-  modelSlug: ModelSlug
+  modelSlug: string
   status: RunStatus
   resultsLocation: string
   exportLocation: string
   workflowRunID?: string
 }
 
-export enum ModelSlug {
-  MRCIDECovidSim = 'mrc-ide-covid-sim',
-  Basel = 'basel',
-  MC19 = 'mc19',
-  IDMCovasim = 'idm-covasim',
-}
-
 export interface Model {
-  slug: ModelSlug
+  slug: string
   imageURL: string
 }

--- a/packages/model-runner/package.json
+++ b/packages/model-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covid-modeling/model-runner",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "main": "dist/index.js",
   "scripts": {
     "test": "PATH=$PATH:../../node_modules/.bin && mocha --debug-brk --ui tdd -r ts-node/register test/unit/*-test.ts",
@@ -19,7 +19,7 @@
   "dependencies": {
     "@azure/identity": "^1.1.0-preview1",
     "@azure/storage-blob": "^12.1.1",
-    "@covid-modeling/api": "0.9.1",
+    "@covid-modeling/api": "^0.10.0",
     "archiver": "^4.0.1",
     "d3": "^5.15.0",
     "dockerode": "^3.2.0",

--- a/packages/model-runner/src/main.ts
+++ b/packages/model-runner/src/main.ts
@@ -1,7 +1,7 @@
 import * as pino from 'pino'
 import * as path from 'path'
 import * as mkdirp from 'mkdirp'
-import { ModelSlug, RunStatus, RequestInput } from '@covid-modeling/api'
+import { RunStatus, RequestInput } from '@covid-modeling/api'
 import { BlobStorage } from './blobstore'
 import { notifyUI } from './notify-ui'
 import { logger } from './logger'
@@ -23,7 +23,7 @@ import { enforceRunnerInputSchema, enforceOutputSchema } from './schema'
 
 let inputID: string | number | null = null
 let callbackURL: string | null = null
-let modelSlug: ModelSlug | null = null
+let modelSlug: string | null = null
 
 const handleRejection: NodeJS.UnhandledRejectionListener = err => {
   const finalLogger = pino.final(logger)

--- a/packages/mrc-ide-covidsim/package.json
+++ b/packages/mrc-ide-covidsim/package.json
@@ -17,7 +17,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@covid-modeling/api": "0.9.*",
+    "@covid-modeling/api": "^0.10.0",
     "d3": "^5.15.0",
     "jsen": "^0.6.6",
     "luxon": "^1.23.0",

--- a/packages/mrc-ide-covidsim/test/integration/imperial-integration-test.ts
+++ b/packages/mrc-ide-covidsim/test/integration/imperial-integration-test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs'
 import { assert } from 'chai'
 import { ImperialModel } from '../../src/imperial'
 import { BIN_DIR, MODEL_DATA_DIR } from '../../src/config'
-import { input, ModelSlug } from '@covid-modeling/api'
+import { input } from '@covid-modeling/api'
 
 suite('imperial integration', () => {
   test('run imperial model for Wyoming', async () => {

--- a/packages/mrc-ide-covidsim/test/unit/convert-output-test.ts
+++ b/packages/mrc-ide-covidsim/test/unit/convert-output-test.ts
@@ -1,5 +1,5 @@
 import { assert } from 'chai'
-import { ModelSlug, input } from '@covid-modeling/api'
+import { input } from '@covid-modeling/api'
 import { convertOutput } from '../../src/convert-output'
 
 const parameters: input.ModelParameters = {
@@ -13,10 +13,6 @@ const parameters: input.ModelParameters = {
 suite('converting imperial model output to JSON', () => {
   test('returns a time series for each metric', () => {
     const input = {
-      model: {
-        slug: ModelSlug.MRCIDECovidSim,
-        imageURL: '',
-      },
       region: 'US',
       subregion: 'US-WY',
       parameters,

--- a/packages/neherlab-covid-19-scenarios/package.json
+++ b/packages/neherlab-covid-19-scenarios/package.json
@@ -17,7 +17,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@covid-modeling/api": "0.9.*",
+    "@covid-modeling/api": "^0.10.0",
     "d3": "^5.15.0",
     "jsen": "^0.6.6",
     "luxon": "^1.23.0",

--- a/packages/neherlab-covid-19-scenarios/test/integration/basel-integration-test.ts
+++ b/packages/neherlab-covid-19-scenarios/test/integration/basel-integration-test.ts
@@ -2,7 +2,7 @@ import * as path from 'path'
 import * as temp from 'temp'
 import * as fs from 'fs'
 import { assert } from 'chai'
-import { input, ModelSlug } from '@covid-modeling/api'
+import { input } from '@covid-modeling/api'
 import { BaselModel } from '../../src/basel'
 import { BIN_DIR, MODEL_DATA_DIR } from '../../src/config'
 

--- a/packages/neherlab-covid-19-scenarios/test/unit/basel-connector-test.ts
+++ b/packages/neherlab-covid-19-scenarios/test/unit/basel-connector-test.ts
@@ -1,5 +1,5 @@
 import { assert } from 'chai'
-import { input, ModelSlug, output } from '@covid-modeling/api'
+import { input, output } from '@covid-modeling/api'
 
 import { AlgorithmResult, Scenario, AllParams } from '../../src/basel-api'
 import { BaselConnector, BaselRunnerModelInput } from '../../src/basel'


### PR DESCRIPTION
This was no longer being used as an enum now that model connectors have
been made independent and their Docker image is supplied as part of the
payload. However, because it was still being validated as part of the
schema it was making it more difficult to add new models.

Closes #15 