### PR TITLE
CovidSim connector: Do not produce network file

### DIFF
--- a/packages/mrc-ide-covidsim/src/imperial.ts
+++ b/packages/mrc-ide-covidsim/src/imperial.ts
@@ -183,7 +183,6 @@ export class ImperialModel implements Model {
       `/P:${input.parametersFilePath}`,
       `/O:${this.outputDir}/result`,
       `/R:${r0 / 2.0}`,
-      `/S:${this.outputDir}/${input.modelInput.region}-${input.subregionName}-network.bin`,
 
       // TODO - cache the intermediate network files
       // '/S:NetworkUKN_32T_100th.bin',


### PR DESCRIPTION
For large regions such as Nigeria, this file can be multiple GB in size.
This sometimes hits the blob storage file upload limits.
For now, do not produce this output.