### PR TITLE
Cache blobstore credentials before making any requests

### DIFF
--- a/packages/model-runner/README.md
+++ b/packages/model-runner/README.md
@@ -1,4 +1,5 @@
 # Development
+
 Ref: [README](../README.md#building)
 
 ## Submitting A Job to the Actions Runners
@@ -18,4 +19,3 @@ Example:
 ```sh
 ./bin/submit-run token.json jobInput.json
 ```
-

--- a/packages/model-runner/src/blobstore.ts
+++ b/packages/model-runner/src/blobstore.ts
@@ -9,6 +9,7 @@ export class BlobStorage {
   storageAccount: string
   containerName: string
   private client: ContainerClient
+  private isAuth: boolean
 
   constructor(storageAccount: string, containerName: string) {
     this.storageAccount = storageAccount
@@ -30,9 +31,7 @@ export class BlobStorage {
     const blobClient = this.client.getBlobClient(key)
     const blockBlobClient = blobClient.getBlockBlobClient()
     // FIXME Some kind of error handling?
-    await blockBlobClient.uploadFile(file, {
-      concurrency: 1,
-    })
+    await blockBlobClient.uploadFile(file)
   }
 
   async uploadOutputDir(dirKey: string, dir: string, isPublic: boolean) {
@@ -59,9 +58,7 @@ export class BlobStorage {
         const blobClient = this.client.getBlobClient(key)
         const blockBlobClient = blobClient.getBlockBlobClient()
         // FIXME Some kind of error handling?
-        await blockBlobClient.uploadFile(globEntry.path, {
-          concurrency: 1,
-        })
+        await blockBlobClient.uploadFile(globEntry.path)
       }
     }
   }
@@ -70,6 +67,14 @@ export class BlobStorage {
     return `simulation-runs/${dirKey}/${
       isPublic ? 'public' : 'private'
     }/${fileName}`
+  }
+
+  async initializeAuth() {
+    if (!this.isAuth) {
+      // see https://github.com/Azure/azure-sdk-for-js/issues/8950#issuecomment-629854244
+      await this.client.getProperties()
+      this.isAuth = true
+    }
   }
 }
 

--- a/packages/model-runner/src/main.ts
+++ b/packages/model-runner/src/main.ts
@@ -131,6 +131,8 @@ async function main() {
     const outputHash = uniqueId(input, imageId)
 
     logger.info('uploading model results to blob storage.')
+    await storage.initializeAuth()
+
     const results = await Promise.allSettled([
       storage.uploadFile(outputFile, outputHash, true),
       storage.uploadFile(exportZipFile, outputHash, true),


### PR DESCRIPTION
Ensure that we have made a call to the remote blobstore that requires the use of credentials before uploading any files. This means that we will not need to authenticate for each upload request and we will not get a 429 response.

See https://github.com/Azure/azure-sdk-for-js/issues/8950#issuecomment-629854244