### PR TITLE
Fix parameters and pre-parameters

### DIFF
--- a/packages/mrc-ide-covidsim/package.json
+++ b/packages/mrc-ide-covidsim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covid-modeling/mrc-ide-covidsim",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "main": "dist/index.js",
   "scripts": {
     "test": "PATH=$PATH:../../node_modules/.bin && mocha --debug-brk --ui tdd -r ts-node/register test/unit/*-test.ts",

--- a/packages/mrc-ide-covidsim/src/imperial-params.ts
+++ b/packages/mrc-ide-covidsim/src/imperial-params.ts
@@ -1,4 +1,4 @@
-import { output, input } from '@covid-modeling/api'
+import { input } from '@covid-modeling/api'
 import { DateTime } from 'luxon'
 import * as assert from 'assert'
 

--- a/packages/mrc-ide-covidsim/src/imperial-params.ts
+++ b/packages/mrc-ide-covidsim/src/imperial-params.ts
@@ -170,7 +170,7 @@ export function assignParameters(p: {}, input: input.ModelParameters) {
 
   // Set all trigger incidences to 0 because we do not support adaptive triggers
   Object.entries(p)
-    .filter(([key]) => key.includes('rigger incidence'))
+    .filter(([key]) => key.toLowerCase().includes('trigger incidence'))
     .forEach(([key, value]) => {
       if (Array.isArray(value)) {
         p[key] = new Array(periodCount).fill(0)

--- a/packages/mrc-ide-covidsim/src/imperial-params.ts
+++ b/packages/mrc-ide-covidsim/src/imperial-params.ts
@@ -125,9 +125,8 @@ export function assignPreParameters(p: {}, input: input.ModelParameters) {
 
   p['Day of year interventions start'] = interventionStartDays
 
-  // if calibration date is before first intervention date, set to 0
-  p['Alert trigger starts after interventions'] =
-    calibrationDays < interventionStartDays ? 0 : 1
+  // This value should always be 1 according to Neil.
+  p['Alert trigger starts after interventions'] = 1
 
   p['Treatment trigger incidence per cell'] = 0
 }

--- a/packages/mrc-ide-covidsim/test/unit/imperial-params-test.ts
+++ b/packages/mrc-ide-covidsim/test/unit/imperial-params-test.ts
@@ -340,27 +340,4 @@ District_of_Columbia	Florida	Georgia
       0.4,
     ])
   })
-
-  test('handles alert trigger starts before interventions', () => {
-    const parameters = {
-      calibrationDate: '2020-02-20',
-      calibrationCaseCount: 500,
-      calibrationDeathCount: 120,
-      r0: 2.5,
-      interventionPeriods: [
-        // Initial intervention
-        {
-          startDate: '2020-03-01',
-          reductionPopulationContact: 9,
-          caseIsolation: input.Intensity.Moderate,
-          socialDistancing: input.Intensity.Mild,
-        },
-      ],
-    }
-    const pp = {}
-
-    params.assignPreParameters(pp, parameters)
-
-    assert.equal(pp['Alert trigger starts after interventions'], 0)
-  })
 })

--- a/packages/mrc-ide-covidsim/test/unit/imperial-params-test.ts
+++ b/packages/mrc-ide-covidsim/test/unit/imperial-params-test.ts
@@ -178,7 +178,10 @@ District_of_Columbia	Florida	Georgia
       ],
     }
 
-    const p = {}
+    const p: Record<string, number | number[] | number[][]> = {
+      'Trigger incidence per cell for social distancing over time': [100, 100],
+      'Household quarantine trigger incidence per cell': 100000,
+    }
     params.assignParameters(p, parameters)
     assert.deepEqual(p, {
       'Vary efficacies over time': 1,
@@ -192,13 +195,11 @@ District_of_Columbia	Florida	Georgia
       'Change times for levels of social distancing': [0, 9, 19, 29],
 
       'Case isolation start time': 0,
-      'Case isolation trigger incidence per cell': 1,
       'Duration of case isolation policy': 10000,
       'Proportion of detected cases isolated over time': [0.75, 0.9, 0.9, 0.75],
 
       'Household quarantine start time': 0,
       'Duration of household quarantine policy': 10000,
-      'Household quarantine trigger incidence per cell': 1,
       'Household level compliance with quarantine over time': [
         0,
         0.75,
@@ -208,7 +209,6 @@ District_of_Columbia	Florida	Georgia
 
       'Social distancing start time': 0,
       'Duration of social distancing': 10000,
-      'Trigger incidence per cell for social distancing': 1,
       'Relative spatial contact rates over time given social distancing': [
         0.5,
         0.1,
@@ -218,7 +218,6 @@ District_of_Columbia	Florida	Georgia
 
       'Place closure start time': 0,
       'Duration of place closure': 10000,
-      'Trigger incidence per cell for place closure': 1,
       'Proportion of places remaining open after closure by place type over time': [
         [1, 1, 1, 1],
         [0.1, 0.1, 0.1, 1],
@@ -226,6 +225,14 @@ District_of_Columbia	Florida	Georgia
         [1, 1, 1, 1],
       ],
       'Duration of place closure over time': [10000, 10000, 10000, 10000],
+
+      'Trigger incidence per cell for social distancing over time': [
+        0,
+        0,
+        0,
+        0,
+      ],
+      'Household quarantine trigger incidence per cell': 0,
     })
 
     const pp = {}
@@ -237,6 +244,7 @@ District_of_Columbia	Florida	Georgia
       'Day of year trigger is reached': 79,
       'Number of days to accummulate cases/deaths before alert': 1000,
       'Number of deaths accummulated before alert': 120,
+      'Treatment trigger incidence per cell': 0,
     })
   })
 

--- a/packages/mrc-ide-covidsim/test/unit/imperial-params-test.ts
+++ b/packages/mrc-ide-covidsim/test/unit/imperial-params-test.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai'
-import { serialize, parse } from '../../src/imperial-params'
 import * as params from '../../src/imperial-params'
+import { parse, serialize } from '../../src/imperial-params'
 import { input } from '@covid-modeling/api'
 
 suite('the imperial model parameter format', () => {
@@ -339,5 +339,28 @@ District_of_Columbia	Florida	Georgia
       0.4,
       0.4,
     ])
+  })
+
+  test('handles alert trigger starts before interventions', () => {
+    const parameters = {
+      calibrationDate: '2020-02-20',
+      calibrationCaseCount: 500,
+      calibrationDeathCount: 120,
+      r0: 2.5,
+      interventionPeriods: [
+        // Initial intervention
+        {
+          startDate: '2020-03-01',
+          reductionPopulationContact: 9,
+          caseIsolation: input.Intensity.Moderate,
+          socialDistancing: input.Intensity.Mild,
+        },
+      ],
+    }
+    const pp = {}
+
+    params.assignPreParameters(pp, parameters)
+
+    assert.equal(pp['Alert trigger starts after interventions'], 0)
   })
 })


### PR DESCRIPTION
1. set ALL references to [Tt]rigger incidences to 0. This is because
   we don't support adaptive triggers.
2. if calibration date is before first intervention date, set 
   'Alert trigger starts after interventions' to 0, otherwise 1.